### PR TITLE
Refactor: Persistence in VisionBoardCard

### DIFF
--- a/Creatist/DataController/Creatist.swift
+++ b/Creatist/DataController/Creatist.swift
@@ -19,6 +19,10 @@ class Creatist {
         return await NetworkManager.shared.post(url: "/auth/signin", body: data)
     }
     
+    func clearUserCache() {
+                visionBoardUserCache.removeAll()
+            }
+    
     func login(email: String, password: String) async -> Bool {
         let loginResponse: LoginResponse? = await _login(email: email, password: password)
         if loginResponse?.message == "success",

--- a/Creatist/VisionBoard/VisionDetailView.swift
+++ b/Creatist/VisionBoard/VisionDetailView.swift
@@ -282,6 +282,7 @@ struct VisionDetailView: View {
     private func addUserToGenre(user: User, genreId: UUID) {
         Task {
             let _ = await Creatist.shared.addAssignmentAndInvite(genreId: genreId, user: user, board: board)
+            Creatist.shared.clearUserCache()
             isLoading = true
             genres = await Creatist.shared.fetchGenresAndAssignments(for: board)
             isLoading = false


### PR DESCRIPTION
The problem was in the loadAssignedUsers function in VisionBoardCard. Even if you updated the users, the cache was not updated and it always displayed what was in the cache, which would be the first request to the backend.
Following the project architecture, what I did to solve it in the simplest way was that when you add a new user to the VisionBoard, the cache is cleared, and when you return to the VisionBoardView, it makes a new call to the backend, updating the screen with the new users. So, while you navigate through the different screens, the VisionBoardCard data is loaded from the cache.

I hope this has been helpful.

Closes #8 