### PR TITLE
managesheet wont be in race condition

### DIFF
--- a/Creatist/VisionBoard/Sheets/CreateVisionBoardSheet.swift
+++ b/Creatist/VisionBoard/Sheets/CreateVisionBoardSheet.swift
@@ -339,8 +339,14 @@ struct CreateVisionBoardSheet: View {
                     onCancel: { showCreatorPickerForGenre = nil }
                 )
             }
-            .sheet(item: $manageSheetGenre) { genre in
-                if let creator = manageSheetCreator {
+            .sheet(isPresented: Binding(
+                get: { manageSheetGenre != nil && manageSheetCreator != nil },
+                set: { if !$0 { 
+                    manageSheetGenre = nil
+                    manageSheetCreator = nil
+                }}
+            )) {
+                if let genre = manageSheetGenre, let creator = manageSheetCreator {
                     ManageCreatorSheet(
                         genre: genre,
                         creator: creator,


### PR DESCRIPTION
The Problem
The original code used .sheet(item: $manageSheetGenre) which would present the sheet as soon as manageSheetGenre was set, but the sheet content depended on manageSheetCreator also being non-nil. This created a race condition where: User clicks "Manage" button
manageSheetGenre gets set immediately
Sheet tries to present but manageSheetCreator might not be ready yet Sheet shows but with no content, appearing as if it didn't open The Solution
I changed the sheet binding from using .sheet(item:) to .sheet(isPresented:) with a custom binding that ensures both manageSheetGenre AND manageSheetCreator are set before presenting the sheet: